### PR TITLE
v0.1.1 - Event schedule to Evoke `FunctionValorantProMatch` for daily data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ The goal of eSportsForge is to create a robust data infrastructure that enables 
 ## Explanation
 At current moment, valorant do not has an easy way to  consume pro matches data. The whole idea of this project is to consume data with web scraping and consolidate that data.
 
+## Data Freshness
+
+This section is to show you the schedule and routines of Lambda Functions.
+
+| LambdaFunction | Event Status | CRON |
+| - | - | - |
+| `FunctionValorantProMatch` | **ENABLE** | `0 12,23 * * ? *`
+
+[AWS Cron Expression](https://docs.aws.amazon.com/systems-manager/latest/userguide/reference-cron-and-rate-expressions.html#reference-cron-and-rate-expressions-intro)
 
 ## Architecture
 ![architecture](./img/architecture.png)

--- a/template.yml
+++ b/template.yml
@@ -44,11 +44,31 @@ Resources:
         - Key: game
           Value: valorant
 
+  # CREATE ROLE TO ALLOW EVENT EVOKE LAMBDA HERE
+  RoleEventBridgeEvokeLambda:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt ValorantResultMatch.Arn
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+
+  ## Event Bridge
+  EventEvokeValorantResumeLambda:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: valorant-resume-match-function
+      Description: Schedule to Evoke Lambda `FunctionValorantProMatch`
+      ScheduleExpression: cron(0 12,23 * * ? *)
+      Targets: 
+      - Arn: !GetAtt ValorantResultMatch.Arn
+        Id: ValorantResultMatch
+        Input: '{"amount_pages": 1}'
+
   ## LAMBDA FUNCTIONS
-  ValorantResultMatchFunction:
+  ValorantResultMatch:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: FunctionValorantProMatches
+      FunctionName: FunctionValorantProMatch
       Description: Function to get resume data from Valorant match.
       Role: !GetAtt RoleLambdaRawValorant.Arn
       Architectures:


### PR DESCRIPTION
Adding an Event at AWS EventBridge to Evoke the Lambda Function `FunctionValorantProMatch` for daily new games.

To be able to set this Event, I've created 2 new resources at AWS.
1. `RoleEventBridgeEvokeLambda` for the event.amazonaws.com be able to evoke any Lambda Function.
2. `EventEvokeValorantResumeLambda` event schedule to run twice a day.