### PR TITLE
v0.1.3 - Athena query data from S3 of Valorant match resume.

### DIFF
--- a/src/athena/raw/match_resume.sql
+++ b/src/athena/raw/match_resume.sql
@@ -1,0 +1,17 @@
+CREATE EXTERNAL TABLE `match_resume`(
+    `result` STRUCT<
+        `match_page`: STRING
+        ,`team1`: STRING
+        ,`team2`: STRING
+        ,`score1`: STRING
+        ,`score2`: STRING
+        ,`tournament_name`: STRING
+        ,`round_info`: STRING
+        ,`dat_load`: STRING
+    >
+)
+ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe' 
+STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat' 
+OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
+LOCATION's3://esport-raw-bucket/game=valorant/'
+TBLPROPERTIES ('classification'='json')

--- a/src/athena/raw/match_resume.sql
+++ b/src/athena/raw/match_resume.sql
@@ -1,13 +1,15 @@
 CREATE EXTERNAL TABLE `match_resume`(
-    `result` STRUCT<
-        `match_page`: STRING
-        ,`team1`: STRING
-        ,`team2`: STRING
-        ,`score1`: STRING
-        ,`score2`: STRING
-        ,`tournament_name`: STRING
-        ,`round_info`: STRING
-        ,`dat_load`: STRING
+    `result` ARRAY<
+        STRUCT<
+            `match_page`: STRING
+            ,`team1`: STRING
+            ,`team2`: STRING
+            ,`score1`: STRING
+            ,`score2`: STRING
+            ,`tournament_name`: STRING
+            ,`round_info`: STRING
+            ,`dat_load`: STRING
+        >
     >
 )
 ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe' 

--- a/src/athena/raw/match_resume.sql
+++ b/src/athena/raw/match_resume.sql
@@ -9,7 +9,7 @@ CREATE EXTERNAL TABLE `match_resume`(
             ,`tournament_name`: STRING
             ,`round_info`: STRING
             ,`dat_load`: STRING
-        >
+        >, `dt`: DATE
     >
 )
 ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe' 

--- a/src/athena/raw/match_resume.sql
+++ b/src/athena/raw/match_resume.sql
@@ -1,4 +1,4 @@
-CREATE EXTERNAL TABLE `match_resume`(
+CREATE EXTERNAL TABLE `valorant_match_resume`(
     `result` ARRAY<
         STRUCT<
             `match_page`: STRING
@@ -8,12 +8,12 @@ CREATE EXTERNAL TABLE `match_resume`(
             ,`score2`: STRING
             ,`tournament_name`: STRING
             ,`round_info`: STRING
-            ,`dat_load`: STRING
-        >, `dt`: DATE
+        >
     >
 )
+PARTITIONED BY (`dt` STRING)
 ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe' 
 STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.TextInputFormat' 
 OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
-LOCATION's3://esport-raw-bucket/game=valorant/'
+LOCATION's3://esport-raw-bucket/game=valorant/content=match_resume/'
 TBLPROPERTIES ('classification'='json')

--- a/src/valorant/FunctionValorantProMatches/app.py
+++ b/src/valorant/FunctionValorantProMatches/app.py
@@ -9,6 +9,7 @@ import boto3
 
 URL = "https://www.vlr.gg/matches/results/"
 S3 = boto3.client('s3')
+S3_KEY = "game=valorant/content=match_resume"
 
 
 def get_matches_pages() -> int:
@@ -90,7 +91,7 @@ def save_tmp_file(data: dict[int]) -> str:
 
 
 def send_to_s3(file_name: str, today: str):
-    partition = f"game=valorant/dt={today}/"
+    partition = f"{S3_KEY}/dt={today}/"
     S3.upload_file(f'/tmp/{file_name}.json', os.getenv('RAW_S3_BUCKET'), f'{partition}{file_name}.json')
 
 
@@ -106,7 +107,6 @@ def main(event, context=None):
     
     for page in range(1, pages + 1):
         games = get_page(page=page)
-        games['dt'] = today
 
         file_name = save_tmp_file(data=games)
         send_to_s3(file_name, today=today)

--- a/src/valorant/FunctionValorantProMatches/app.py
+++ b/src/valorant/FunctionValorantProMatches/app.py
@@ -21,7 +21,7 @@ def get_matches_pages() -> int:
     return last_page
 
 
-def get_page(page: int, today: str) -> dict[list]:
+def get_page(page: int) -> dict[list]:
     page_url = str(URL + f"?page={page}")
     result = requests.get(url=page_url)
     html = HTMLParser(html=result.text)
@@ -71,8 +71,7 @@ def get_page(page: int, today: str) -> dict[list]:
                 "score1": score1,
                 "score2": score2,
                 "tournament_name": tourney,
-                "round_info": rounds,
-                "dat_load": today
+                "round_info": rounds
             }
         )
 
@@ -107,6 +106,7 @@ def main(event, context=None):
     
     for page in range(1, pages + 1):
         games = get_page(page=page, today=str(today))
+        games['dt'] = today
 
         file_name = save_tmp_file(data=games)
         send_to_s3(file_name, today=today)
@@ -114,3 +114,8 @@ def main(event, context=None):
         # We are not requesting data from an API, so takecare.
         print(f"DATA FROM PAGE {page} UPLOADED TO S3")
         sleep(0.5)
+
+if __name__ == "__main__":
+    main(event={
+    "amount_pages": 1
+})

--- a/src/valorant/FunctionValorantProMatches/app.py
+++ b/src/valorant/FunctionValorantProMatches/app.py
@@ -96,7 +96,7 @@ def send_to_s3(file_name: str, today: str):
 
 def main(event, context=None):
     pages = 0
-    today = date.today()
+    today = str(date.today())
 
     if "amount_pages" not in event:
         pages = get_matches_pages()
@@ -105,7 +105,7 @@ def main(event, context=None):
         pages = event["amount_pages"]
     
     for page in range(1, pages + 1):
-        games = get_page(page=page, today=str(today))
+        games = get_page(page=page)
         games['dt'] = today
 
         file_name = save_tmp_file(data=games)
@@ -114,8 +114,3 @@ def main(event, context=None):
         # We are not requesting data from an API, so takecare.
         print(f"DATA FROM PAGE {page} UPLOADED TO S3")
         sleep(0.5)
-
-if __name__ == "__main__":
-    main(event={
-    "amount_pages": 1
-})

--- a/template.yml
+++ b/template.yml
@@ -10,6 +10,17 @@ Parameters:
 # Resources section
 Resources:
   ## S3
+  AthenaOutput:
+    Type: 'AWS::S3::Bucket'
+    DeletionPolicy: Delete
+    Properties:
+      BucketName: esport-athena-bucket
+      LifecycleConfiguration:
+        Rules: 
+          - Id: DeleteAthenaOutput
+            Status: Enabled
+            ExpirationInDays: 7
+
   RawS3Bucket:
     Type: 'AWS::S3::Bucket'
     DeletionPolicy: Retain


### PR DESCRIPTION
Improving S3 Raw Bucket partitioning by using `/game=valorant/content=match_resume/dt=YYYY-MM-DD`.

1. Creating Athena `raw` database for query;
2. S3 `esports-athena-bucket` for Athena's output;
3. Athena table `valiant_match_resume` with PARTITION BY `dt` from S3 key;
4. Removing `dt` from JSON file in `FunctionValorantProMatch`.